### PR TITLE
Fixes a compilation error for gcc and clang. Changes solver_homograph…

### DIFF
--- a/src/pygcransac/include/solver_homography_four_point.h
+++ b/src/pygcransac/include/solver_homography_four_point.h
@@ -83,14 +83,14 @@ namespace gcransac
 					const double *weights_ = nullptr) const; // The weight for each point
 
 			protected:
-				OLGA_INLINE bool HomographyFourPointSolver::estimateNonMinimalModel(
+				OLGA_INLINE bool estimateNonMinimalModel(
 					const cv::Mat& data_,
 					const size_t* sample_,
 					size_t sample_number_,
 					std::vector<Model>& models_,
 					const double* weights_) const;
 
-				OLGA_INLINE bool HomographyFourPointSolver::estimateMinimalModel(
+				OLGA_INLINE bool estimateMinimalModel(
 					const cv::Mat& data_,
 					const size_t* sample_,
 					size_t sample_number_,


### PR DESCRIPTION
This fixes an "extra qualification" compilation error that occurs with both gcc and clang. This makes a tiny change to solver_homography_four_point.h to remove the extra qualifications.

This is an example of the compilation error:
~~~~
error: extra qualification 'gcransac::estimator::solver::HomographyFourPointSolver::' on member 'estimateNonMinimalModel' [-fpermissive]
   86 |     OLGA_INLINE bool HomographyFourPointSolver::estimateNonMinimalModel(
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~
~~~~

Just for reference: https://stackoverflow.com/questions/5642367/extra-qualification-error-in-c