### PR TITLE
feat: add a process-wide random seed to UniformRandomGenerator

### DIFF
--- a/src/pygcransac/include/uniform_random_generator.h
+++ b/src/pygcransac/include/uniform_random_generator.h
@@ -35,6 +35,8 @@
 
 #include <random>
 #include <algorithm>
+#include <optional>
+#include <cstdint>
 
 namespace gcransac
 {
@@ -47,10 +49,27 @@ namespace gcransac
 			std::mt19937 generator;
 			std::uniform_int_distribution<_ValueType> generate;
 
+			// Process-wide fixed seed for reproducibility. When set (see
+			// setGlobalSeed), every newly constructed generator is seeded
+			// deterministically instead of from std::random_device. Mirrors
+			// the cv::setRNGSeed pattern. Intended for debugging/repeatable runs.
+			inline static std::optional<std::uint64_t> fixed_seed = std::nullopt;
+
 		public:
+			// Make all subsequently-constructed UniformRandomGenerators
+			// deterministic with the given seed (until clearGlobalSeed()).
+			static void setGlobalSeed(std::uint64_t seed) { fixed_seed = seed; }
+			// Restore nondeterministic (std::random_device) seeding.
+			static void clearGlobalSeed() { fixed_seed = std::nullopt; }
+
 			UniformRandomGenerator() {
-				std::random_device rand_dev;
-				generator = std::mt19937(rand_dev());
+				if (fixed_seed.has_value())
+					generator = std::mt19937(static_cast<std::mt19937::result_type>(*fixed_seed));
+				else
+				{
+					std::random_device rand_dev;
+					generator = std::mt19937(rand_dev());
+				}
 			}
 
 			~UniformRandomGenerator() {


### PR DESCRIPTION
# feat: add a process-wide random seed to `UniformRandomGenerator`

## What

Adds `UniformRandomGenerator::setGlobalSeed(uint64_t)` and `clearGlobalSeed()`
(`src/pygcransac/include/uniform_random_generator.h`). When a seed is set, every
subsequently constructed generator is seeded deterministically
(`std::mt19937(seed)`) instead of from `std::random_device`; clearing restores the
default. Default behavior (no seed) is unchanged.

This mirrors OpenCV's `cv::setRNGSeed` — a process-wide reproducibility switch.

## Why

There is currently no way to make RANSAC sampling reproducible, which makes
debugging non-deterministic failures hard. A fixed seed gives repeatable runs.

## Coverage

- **All URG-based samplers** (`UniformSampler`, `ProsacSampler`,
  `ProgressiveNapsacSampler`, `ImportanceSampler`) build their generator via the
  default `UniformRandomGenerator()` constructor, so they honor the global seed
  with **no per-sampler change**.
- Samplers/solvers that use `std::rand()` / `Eigen::…::Random()`
  (`AdaptiveReorderingSampler`, PnP bundle-adjustment, DLS/SIFT solvers) are not
  driven by this generator; the **caller** makes those reproducible with
  `std::srand(seed)` (`Eigen::Random` uses `std::rand` by default).
- Caveat: composite samplers that hold nested generators (Progressive-NAPSAC)
  will seed each nested generator with the same value → correlated sub-sequences.
  Fine for reproducible debugging; deriving distinct sub-seeds is a possible
  later refinement.

## Companion PR

This is the enabling change. The seed is exposed to users through the `seed`
parameter added to the `pymagsac` Python API in the companion **magsac** PR,
https://github.com/danini/magsac/pull/48, which calls
`setGlobalSeed(seed)` + `std::srand(seed)` before running. That PR **depends on
this one** (and bumps the submodule to this commit).
