### PR TITLE
fix: guard LinearModelSolver minimal fast-path against a null sample

### DIFF
--- a/src/pygcransac/include/estimators/solver_linear_model.h
+++ b/src/pygcransac/include/estimators/solver_linear_model.h
@@ -199,7 +199,7 @@ namespace gcransac
 				// we address them accordingly.
 				if constexpr (_DimensionNumber == 2) 
 					// 2D line fitting from a minimal sample, i.e., 2 points
-					if (sampleNumber_ == sampleSize())
+					if (sampleNumber_ == sampleSize() && sample_ != nullptr)
 						return estimate2DLine(
 							data_,
 							sample_,
@@ -209,7 +209,7 @@ namespace gcransac
 
 				if constexpr (_DimensionNumber == 3)
 					// 3D plane fitting from a minimal sample, i.e., 3 points
-					if (sampleNumber_ == sampleSize())
+					if (sampleNumber_ == sampleSize() && sample_ != nullptr)
 						return estimate3DPlane(data_,
 							sample_,
 							sampleNumber_,


### PR DESCRIPTION
# fix: guard LinearModelSolver minimal fast-path against a null sample

## Problem

`LinearModelSolver<2>` / `<3>` (`estimators/solver_linear_model.h`) has a
minimal-sample fast-path in `estimateModel`:

```cpp
if constexpr (_DimensionNumber == 2)
    if (sampleNumber_ == sampleSize())
        return estimate2DLine(data_, sample_, ...);   // derefs sample_[0..1]

if constexpr (_DimensionNumber == 3)
    if (sampleNumber_ == sampleSize())
        return estimate3DPlane(data_, sample_, ...);  // derefs sample_[0..2]
```

`estimate2DLine`/`estimate3DPlane` index `sample_[0..k-1]`. But `estimateModel`
**explicitly supports `sample_ == nullptr`** (meaning "use the first
`sampleNumber_` points") — the general path right below it does exactly that via
`const int sampleIdx = sample_ == nullptr ? pointIdx : sample_[pointIdx];`.

So when the **non-minimal** fit is called with `sample_ == nullptr` **and**
`sampleNumber_ == sampleSize()`, the fast-path dereferences a null pointer and
crashes. This happens in MAGSAC's IRLS (`sigmaConsensusPlusPlus`), which refits
on all collected inliers passing `sample_ = nullptr`; when the inlier count is
exactly `sampleSize()` (3 for a plane, 2 for a line) it hits the fast-path.

## Fix

Only take the minimal fast-path when the sample is non-null; otherwise fall
through to the general, null-safe path:

```cpp
if (sampleNumber_ == sampleSize() && sample_ != nullptr)
```

Two-character change at each of the two sites. No behavior change for non-null
samples (the general path produces the same minimal-sample result).

## Reproduction

Calling the non-minimal path directly with a null sample:

```cpp
LinearModelSolver<3> solver;                 // 3D plane, sampleSize() == 3
solver.estimateModel(data, /*sample=*/nullptr, /*sampleNumber=*/3, models, nullptr);
```

- **Before:** `AddressSanitizer: SEGV on address 0x0` at
  `estimate3DPlane (solver_linear_model.h)`.
- **After:** returns normally (general path), no crash.

## Scope

Standalone crash fix, branched from `master`, one file, zero coupling to the
gamma/DoF/scoring work. (It was previously bundled into the per-estimator-DoF
PR https://github.com/danini/graph-cut-ransac/pull/50; it is extracted here so it
can merge independently.)
